### PR TITLE
Notify on green price transitions

### DIFF
--- a/cheap_electricity/main.py
+++ b/cheap_electricity/main.py
@@ -3,6 +3,7 @@ import asyncio
 from cheap_electricity.esios import get_prices_for_today
 from cheap_electricity.price_processing import process_and_categorize_prices
 from cheap_electricity.notifications import send_telegram_notification
+from cheap_electricity.price import PriceCategory
 
 
 async def main() -> None:
@@ -10,19 +11,26 @@ async def main() -> None:
     if not price_data:
         return
 
-    current_price, category = process_and_categorize_prices(price_data)
-    if current_price is None:
+    current_price, previous_price = process_and_categorize_prices(price_data)
+    if current_price is None or previous_price is None:
         return
 
-    color_map = {"Green": "\033[92m", "Yellow": "\033[93m", "Red": "\033[91m"}
+    color_map = {
+        PriceCategory.GREEN: "\033[92m",
+        PriceCategory.YELLOW: "\033[93m",
+        PriceCategory.RED: "\033[91m",
+    }
     color_end = "\033[0m"
+    category = current_price.category
     print(
-        f"The current price is {current_price} €/MWh. "
-        f"Category: {color_map.get(category, '')}{category or ''}{color_end}"
+        f"The current price is {current_price.value} {current_price.unit}. "
+        f"Category: {color_map.get(category, '')}{category.value}{color_end}"
     )
 
-    if category == "Green":
-        await send_telegram_notification(current_price)
+    prev_green = previous_price.category is PriceCategory.GREEN
+    curr_green = current_price.category is PriceCategory.GREEN
+    if prev_green != curr_green:
+        await send_telegram_notification(current_price, previous_price)
 
 
 if __name__ == "__main__":

--- a/cheap_electricity/notifications.py
+++ b/cheap_electricity/notifications.py
@@ -1,15 +1,27 @@
 from telegram import Bot
 
 from . import config
+from .price import Price, PriceCategory
 
 
-async def send_telegram_notification(price: float) -> None:
+async def send_telegram_notification(current: Price, previous: Price) -> None:
     if not config.TELEGRAM_BOT_TOKEN or not config.TELEGRAM_CHAT_ID:
         print("Error: Telegram environment variables not set in .env")
         return
 
     bot = Bot(token=config.TELEGRAM_BOT_TOKEN)
-    message = f"Time for cheap power! 🟢\nThe current price is {price} €/MWh."
+    if current.category is PriceCategory.GREEN:
+        message = (
+            "Time for cheap power! 🟢\n"
+            f"Price changed from {previous.value} {previous.unit} ({previous.category.value}) "
+            f"to {current.value} {current.unit} ({current.category.value})."
+        )
+    else:
+        message = (
+            "Cheap power period ended.\n"
+            f"Price changed from {previous.value} {previous.unit} ({previous.category.value}) "
+            f"to {current.value} {current.unit} ({current.category.value})."
+        )
 
     try:
         await bot.send_message(chat_id=config.TELEGRAM_CHAT_ID, text=message)

--- a/cheap_electricity/price.py
+++ b/cheap_electricity/price.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class PriceCategory(Enum):
+    GREEN = "Green"
+    YELLOW = "Yellow"
+    RED = "Red"
+
+
+@dataclass
+class Price:
+    hour: datetime
+    value: float
+    unit: str
+    category: PriceCategory

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -4,12 +4,19 @@ from unittest.mock import AsyncMock, patch
 
 from tests.mock_data import MOCK_PRICES_DATA
 from cheap_electricity.main import main
+from cheap_electricity.price import PriceCategory
 
 
 class FixedDateTime(datetime.datetime):
     @classmethod
     def now(cls, tz=None):
         return cls(2025, 8, 7, 1, 0, 0)
+
+
+class FixedDateTimeExit(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2025, 8, 7, 2, 0, 0)
 
 
 def test_main_triggers_notification(monkeypatch):
@@ -20,4 +27,25 @@ def test_main_triggers_notification(monkeypatch):
     with patch("cheap_electricity.price_processing.datetime.datetime", FixedDateTime):
         asyncio.run(main())
 
-    async_mock.assert_awaited_once_with(90.0)
+    async_mock.assert_awaited_once()
+    current, previous = async_mock.call_args[0]
+    assert current.value == 90.0
+    assert current.category is PriceCategory.GREEN
+    assert previous.value == 100.0
+    assert previous.category is PriceCategory.YELLOW
+
+
+def test_main_triggers_notification_on_exit(monkeypatch):
+    monkeypatch.setattr("cheap_electricity.main.get_prices_for_today", lambda: MOCK_PRICES_DATA)
+    async_mock = AsyncMock()
+    monkeypatch.setattr("cheap_electricity.main.send_telegram_notification", async_mock)
+
+    with patch("cheap_electricity.price_processing.datetime.datetime", FixedDateTimeExit):
+        asyncio.run(main())
+
+    async_mock.assert_awaited_once()
+    current, previous = async_mock.call_args[0]
+    assert current.value == 150.0
+    assert current.category is PriceCategory.YELLOW
+    assert previous.value == 90.0
+    assert previous.category is PriceCategory.GREEN

--- a/tests/test_price_processing.py
+++ b/tests/test_price_processing.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from tests.mock_data import MOCK_PRICES_DATA
 from cheap_electricity.price_processing import process_and_categorize_prices
+from cheap_electricity.price import PriceCategory
 
 
 class FixedDateTimeGreen(datetime.datetime):
@@ -25,20 +26,26 @@ class FixedDateTimeRed(datetime.datetime):
 
 def test_process_and_categorize_prices_green():
     with patch("cheap_electricity.price_processing.datetime.datetime", FixedDateTimeGreen):
-        price, category = process_and_categorize_prices(MOCK_PRICES_DATA)
-    assert price == 90.0
-    assert category == "Green"
+        current, previous = process_and_categorize_prices(MOCK_PRICES_DATA)
+    assert current.value == 90.0
+    assert current.category is PriceCategory.GREEN
+    assert previous.value == 100.0
+    assert previous.category is PriceCategory.YELLOW
 
 
 def test_process_and_categorize_prices_yellow():
     with patch("cheap_electricity.price_processing.datetime.datetime", FixedDateTimeYellow):
-        price, category = process_and_categorize_prices(MOCK_PRICES_DATA)
-    assert price == 100.0
-    assert category == "Yellow"
+        current, previous = process_and_categorize_prices(MOCK_PRICES_DATA)
+    assert current.value == 100.0
+    assert current.category is PriceCategory.YELLOW
+    assert previous.value == 250.0
+    assert previous.category is PriceCategory.RED
 
 
 def test_process_and_categorize_prices_red():
     with patch("cheap_electricity.price_processing.datetime.datetime", FixedDateTimeRed):
-        price, category = process_and_categorize_prices(MOCK_PRICES_DATA)
-    assert price == 230.0
-    assert category == "Red"
+        current, previous = process_and_categorize_prices(MOCK_PRICES_DATA)
+    assert current.value == 230.0
+    assert current.category is PriceCategory.RED
+    assert previous.value == 75.0
+    assert previous.category is PriceCategory.GREEN

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,8 +1,10 @@
 import asyncio
 import types
+import datetime
 from unittest.mock import AsyncMock
 
 from cheap_electricity.notifications import send_telegram_notification
+from cheap_electricity.price import Price, PriceCategory
 
 
 def build_bot(async_mock):
@@ -11,12 +13,59 @@ def build_bot(async_mock):
     return bot
 
 
-def test_send_telegram_notification(monkeypatch):
+def test_send_telegram_notification_green(monkeypatch):
     async_mock = AsyncMock()
     monkeypatch.setattr("cheap_electricity.notifications.Bot", lambda token: build_bot(async_mock))
     monkeypatch.setattr("cheap_electricity.config.TELEGRAM_BOT_TOKEN", "TOKEN")
     monkeypatch.setattr("cheap_electricity.config.TELEGRAM_CHAT_ID", "CHAT")
 
-    asyncio.run(send_telegram_notification(123.45))
+    current = Price(
+        hour=datetime.datetime.now(),
+        value=90.0,
+        unit="€/MWh",
+        category=PriceCategory.GREEN,
+    )
+    previous = Price(
+        hour=datetime.datetime.now(),
+        value=100.0,
+        unit="€/MWh",
+        category=PriceCategory.YELLOW,
+    )
+    asyncio.run(send_telegram_notification(current, previous))
 
-    async_mock.assert_awaited_once_with(chat_id="CHAT", text="Time for cheap power! 🟢\nThe current price is 123.45 €/MWh.")
+    async_mock.assert_awaited_once_with(
+        chat_id="CHAT",
+        text=(
+            "Time for cheap power! 🟢\n"
+            "Price changed from 100.0 €/MWh (Yellow) to 90.0 €/MWh (Green)."
+        ),
+    )
+
+
+def test_send_telegram_notification_non_green(monkeypatch):
+    async_mock = AsyncMock()
+    monkeypatch.setattr("cheap_electricity.notifications.Bot", lambda token: build_bot(async_mock))
+    monkeypatch.setattr("cheap_electricity.config.TELEGRAM_BOT_TOKEN", "TOKEN")
+    monkeypatch.setattr("cheap_electricity.config.TELEGRAM_CHAT_ID", "CHAT")
+
+    current = Price(
+        hour=datetime.datetime.now(),
+        value=50.0,
+        unit="€/MWh",
+        category=PriceCategory.RED,
+    )
+    previous = Price(
+        hour=datetime.datetime.now(),
+        value=123.45,
+        unit="€/MWh",
+        category=PriceCategory.GREEN,
+    )
+    asyncio.run(send_telegram_notification(current, previous))
+
+    async_mock.assert_awaited_once_with(
+        chat_id="CHAT",
+        text=(
+            "Cheap power period ended.\n"
+            "Price changed from 123.45 €/MWh (Green) to 50.0 €/MWh (Red)."
+        ),
+    )


### PR DESCRIPTION
## Summary
- Replace string categories with `PriceCategory` enum in `Price` dataclass and processing logic
- Include both previous and current prices in Telegram alerts when entering or exiting green pricing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894d0be518083299f5e443735773174