### PR TITLE
Refactor PriceCategory into class with color and emoji

### DIFF
--- a/cheap_electricity/main.py
+++ b/cheap_electricity/main.py
@@ -3,7 +3,7 @@ import asyncio
 from cheap_electricity.esios import get_prices_for_today
 from cheap_electricity.price_processing import process_and_categorize_prices
 from cheap_electricity.notifications import send_telegram_notification
-from cheap_electricity.price import PriceCategory
+from cheap_electricity.price import ColorEnum
 
 
 async def main() -> None:
@@ -16,19 +16,19 @@ async def main() -> None:
         return
 
     color_map = {
-        PriceCategory.GREEN: "\033[92m",
-        PriceCategory.YELLOW: "\033[93m",
-        PriceCategory.RED: "\033[91m",
+        ColorEnum.GREEN: "\033[92m",
+        ColorEnum.YELLOW: "\033[93m",
+        ColorEnum.RED: "\033[91m",
     }
     color_end = "\033[0m"
     category = current_price.category
     print(
         f"The current price is {current_price.value} {current_price.unit}. "
-        f"Category: {color_map.get(category, '')}{category.value}{color_end}"
+        f"Category: {color_map.get(category.color, '')}{category.color.value}{color_end}"
     )
 
-    prev_green = previous_price.category is PriceCategory.GREEN
-    curr_green = current_price.category is PriceCategory.GREEN
+    prev_green = previous_price.category.color is ColorEnum.GREEN
+    curr_green = current_price.category.color is ColorEnum.GREEN
     if prev_green != curr_green:
         await send_telegram_notification(current_price, previous_price)
 

--- a/cheap_electricity/notifications.py
+++ b/cheap_electricity/notifications.py
@@ -1,7 +1,7 @@
 from telegram import Bot
 
 from . import config
-from .price import Price, PriceCategory
+from .price import Price, ColorEnum
 
 
 async def send_telegram_notification(current: Price, previous: Price) -> None:
@@ -10,17 +10,17 @@ async def send_telegram_notification(current: Price, previous: Price) -> None:
         return
 
     bot = Bot(token=config.TELEGRAM_BOT_TOKEN)
-    if current.category is PriceCategory.GREEN:
+    if current.category.color is ColorEnum.GREEN:
         message = (
-            "Time for cheap power! 🟢\n"
-            f"Price changed from {previous.value} {previous.unit} ({previous.category.value}) "
-            f"to {current.value} {current.unit} ({current.category.value})."
+            f"Time for cheap power! {current.category.emoji}\n"
+            f"Price changed from {previous.value} {previous.unit} ({previous.category.color.value}) "
+            f"to {current.value} {current.unit} ({current.category.color.value})."
         )
     else:
         message = (
             "Cheap power period ended.\n"
-            f"Price changed from {previous.value} {previous.unit} ({previous.category.value}) "
-            f"to {current.value} {current.unit} ({current.category.value})."
+            f"Price changed from {previous.value} {previous.unit} ({previous.category.color.value}) "
+            f"to {current.value} {current.unit} ({current.category.color.value})."
         )
 
     try:

--- a/cheap_electricity/price.py
+++ b/cheap_electricity/price.py
@@ -3,10 +3,22 @@ from datetime import datetime
 from enum import Enum
 
 
-class PriceCategory(Enum):
+class ColorEnum(Enum):
     GREEN = "Green"
     YELLOW = "Yellow"
     RED = "Red"
+
+
+@dataclass(frozen=True)
+class PriceCategory:
+    color: ColorEnum
+    emoji: str
+
+
+# Predefined categories
+PriceCategory.GREEN = PriceCategory(ColorEnum.GREEN, "\U0001F7E2")
+PriceCategory.YELLOW = PriceCategory(ColorEnum.YELLOW, "\U0001F7E1")
+PriceCategory.RED = PriceCategory(ColorEnum.RED, "\U0001F534")
 
 
 @dataclass

--- a/tests/test_main_flow.py
+++ b/tests/test_main_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 from tests.mock_data import MOCK_PRICES_DATA
 from cheap_electricity.main import main
-from cheap_electricity.price import PriceCategory
+from cheap_electricity.price import ColorEnum
 
 
 class FixedDateTime(datetime.datetime):
@@ -30,9 +30,9 @@ def test_main_triggers_notification(monkeypatch):
     async_mock.assert_awaited_once()
     current, previous = async_mock.call_args[0]
     assert current.value == 90.0
-    assert current.category is PriceCategory.GREEN
+    assert current.category.color is ColorEnum.GREEN
     assert previous.value == 100.0
-    assert previous.category is PriceCategory.YELLOW
+    assert previous.category.color is ColorEnum.YELLOW
 
 
 def test_main_triggers_notification_on_exit(monkeypatch):
@@ -46,6 +46,6 @@ def test_main_triggers_notification_on_exit(monkeypatch):
     async_mock.assert_awaited_once()
     current, previous = async_mock.call_args[0]
     assert current.value == 150.0
-    assert current.category is PriceCategory.YELLOW
+    assert current.category.color is ColorEnum.YELLOW
     assert previous.value == 90.0
-    assert previous.category is PriceCategory.GREEN
+    assert previous.category.color is ColorEnum.GREEN

--- a/tests/test_price_processing.py
+++ b/tests/test_price_processing.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from tests.mock_data import MOCK_PRICES_DATA
 from cheap_electricity.price_processing import process_and_categorize_prices
-from cheap_electricity.price import PriceCategory
+from cheap_electricity.price import ColorEnum
 
 
 class FixedDateTimeGreen(datetime.datetime):
@@ -28,24 +28,24 @@ def test_process_and_categorize_prices_green():
     with patch("cheap_electricity.price_processing.datetime.datetime", FixedDateTimeGreen):
         current, previous = process_and_categorize_prices(MOCK_PRICES_DATA)
     assert current.value == 90.0
-    assert current.category is PriceCategory.GREEN
+    assert current.category.color is ColorEnum.GREEN
     assert previous.value == 100.0
-    assert previous.category is PriceCategory.YELLOW
+    assert previous.category.color is ColorEnum.YELLOW
 
 
 def test_process_and_categorize_prices_yellow():
     with patch("cheap_electricity.price_processing.datetime.datetime", FixedDateTimeYellow):
         current, previous = process_and_categorize_prices(MOCK_PRICES_DATA)
     assert current.value == 100.0
-    assert current.category is PriceCategory.YELLOW
+    assert current.category.color is ColorEnum.YELLOW
     assert previous.value == 250.0
-    assert previous.category is PriceCategory.RED
+    assert previous.category.color is ColorEnum.RED
 
 
 def test_process_and_categorize_prices_red():
     with patch("cheap_electricity.price_processing.datetime.datetime", FixedDateTimeRed):
         current, previous = process_and_categorize_prices(MOCK_PRICES_DATA)
     assert current.value == 230.0
-    assert current.category is PriceCategory.RED
+    assert current.category.color is ColorEnum.RED
     assert previous.value == 75.0
-    assert previous.category is PriceCategory.GREEN
+    assert previous.category.color is ColorEnum.GREEN


### PR DESCRIPTION
## Summary
- Replace `PriceCategory` enum with data class storing `ColorEnum` and emoji
- Adapt main logic and telegram notifications to use `ColorEnum` comparisons
- Update tests to assert against `ColorEnum`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ebf417448329b8c1af18474145db